### PR TITLE
fix: implement generic default behavior for unsupported warehouses

### DIFF
--- a/macros/drop_old_relations.sql
+++ b/macros/drop_old_relations.sql
@@ -2,7 +2,7 @@
 	{{ return(adapter.dispatch('drop_old_relations', 'tasman_dbt_utils')(schema_prefix, database, dry_run)) }}
 {%- endmacro %}
 
-{% macro bigquery__drop_old_relations(size) %}
+{% macro default__drop_old_relations(size) %}
     {{ exceptions.raise_compiler_error("This macro is not supported in BigQuery.") }}
 {% endmacro %}
 

--- a/macros/get_object_keys.sql
+++ b/macros/get_object_keys.sql
@@ -2,7 +2,7 @@
     {{ return(adapter.dispatch('get_object_keys', 'tasman_dbt_utils')(column, table, database, schema)) }}
 {%- endmacro %}
 
-{% macro bigquery__get_object_keys(size) %}
+{% macro default__get_object_keys(size) %}
     {{ exceptions.raise_compiler_error("This macro is not supported in BigQuery.") }}
 {% endmacro %}
 

--- a/macros/set_warehouse_size.sql
+++ b/macros/set_warehouse_size.sql
@@ -2,7 +2,7 @@
 	{{ return(adapter.dispatch('set_warehouse_size', 'tasman_dbt_utils')(size)) }}
 {% endmacro %}
 
-{% macro bigquery__set_warehouse_size(size) %}
+{% macro default__set_warehouse_size(size) %}
     {{ exceptions.raise_compiler_error("This macro is not supported in BigQuery.") }}
 {% endmacro %}
 


### PR DESCRIPTION
- [x] Implement default behavior for unsupported warehouses

This makes it easier to extend the package with warehouse specific functionality, while avoiding it breaking when onboarding new warehouses, such as Trino