### PR TITLE
Feature/improve source tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ packages:
 #### test_count_distinct_matches_source ([source](tests/generic/test_count_distinct_matches_source.sql))
 
 1. Count distinct of the test column (e.g. transaction_id)
-2. Aggregates this by a specified field (e.g. date) to get a aggregated measure (e.g. date | count_transactions)
-3. Compares this against another model (ideally with the same granularity) (e.g. date | count_transactions)
+2. Aggregates this by a specified list of fields (e.g. date, country, platform) to get a aggregated measure (e.g. date | country | platform | count_transactions)
+3. Compares this against another model (ideally with the same granularity) (e.g. date | country | platform | count_transactions)
 4. Returns any rows where there is a discrepancy between the aggregated measures
 5. (Bonus) If you are fine with tests not being an exact match, then you can specify a threshold for which failures can occur e.g. count transactions can fluctuate within ±5% range from source
 
@@ -60,7 +60,8 @@ packages:
 -   `source_model` (required): The name of the model that contains the source of truth. Specify this as a ref function e.g. `ref('raw_jaffle_shop')`.
     -   These can be seed files or dbt models, so there's a degree of flexibility here
 -   `source_metric` (required): The name of the column/metric sourced from `source_model`
--   `comparison_field` (required): The name of the column/metric sourced from `model` in the YAML file i.e. the column/metric that is being compared against
+-   `source_field` (required): The list of name(s) of the column/dimensions sourced from `source_model` that you'd like to group by
+-   `comparison_field` (required): The list of name(s) of the column/dimensions sourced from `model` in the YAML file i.e. the column/dimension that is being compared against
 -   `percent_mismatch_threshold` (optional, default = 0): The threshold that you would allow your tests to be out by. e.g. if you are happy with ±5% discrepancy, then set to 5.
 
 **Usage**
@@ -84,9 +85,15 @@ models:
           - count_aggregate_matches_source:
               name: count_transactions_matches_source__dmn_jaffle_shop
               source_model: ref('raw_jaffle_shop')
-              source_field: sale_date
+              source_field:
+                - sale_date
+                - user_country
+                - mobile_platform
               source_metric: transaction_amount
-              comparison_field: date_trunc(day, created_timestamp)
+              comparison_field: 
+                - date_trunc(day, created_timestamp)
+                - country
+                - platform
               config:
                 where: date_trunc(day, created_timestamp) between '2022-01-11' and '2022-12-31' and sale_type != 'CANCELLED'
 ```
@@ -98,17 +105,18 @@ models:
 #### test_sum_matches_source ([source](tests/generic/test_sum_matches_source.sql))
 
 1. Sum of the test column (e.g. revenue)
-2. Aggregates this by a specified field (e.g. date) to get a aggregated measure (e.g. date | sum_revenue)
-3. Compares this against another model (ideally with the same granularity) (e.g. date | sum_revenue)
+2. Aggregates this by a specified field (e.g. date, country, platform) to get a aggregated measure (e.g. date | country | platform | sum_revenue)
+3. Compares this against another model (ideally with the same granularity) (e.g. date | country | platform | sum_revenue)
 4. Returns any rows where there is a discrepancy between the aggregated measures
 5. (Bonus) If you are fine with tests not being an exact match, then you can specify a threshold for which failures can occur e.g. Sum revenue can fluctuate within ±5% range from source
 
 **Arguments**
 
--   `source_model` (required): The name of the model that contains the source of truth. Specify this as a ref function e.g. `ref('raw_jaffle_shop')`
+-   `source_model` (required): The name of the model that contains the source of truth. Specify this as a ref function e.g. `ref('raw_jaffle_shop')`.
     -   These can be seed files or dbt models, so there's a degree of flexibility here
 -   `source_metric` (required): The name of the column/metric sourced from `source_model`
--   `comparison_field` (required): The name of the column/metric sourced from `model` in the YAML file i.e. the column/metric that is being compared against
+-   `source_field` (required): The list of name(s) of the column/dimensions sourced from `source_model` that you'd like to group by
+-   `comparison_field` (required): The list of name(s) of the column/dimensions sourced from `model` in the YAML file i.e. the column/dimension that is being compared against
 -   `percent_mismatch_threshold` (optional, default = 0): The threshold that you would allow your tests to be out by. e.g. if you are happy with ±5% discrepancy, then set to 5.
 
 **Usage**
@@ -131,9 +139,15 @@ models:
           - sum_aggregate_matches_source:
               name: sum_revenue_matches_source__dmn_jaffle_shop
               source_model: ref('raw_jaffle_shop')
-              source_field: sale_date
+              source_field: 
+                - sale_date
+                - user_country
+                - mobile_platform
               source_metric: sum_revenue
-              comparison_field: date_trunc(day, created_timestamp)
+              comparison_field: 
+                - date_trunc(day, created_timestamp)
+                - country
+                - platform
               config:
                 where: date_trunc(day, created_timestamp) between '2022-01-11' and '2022-12-31' and sale_type != 'CANCELLED'
 ```

--- a/tests/generic/test_count_distinct_matches_source.sql
+++ b/tests/generic/test_count_distinct_matches_source.sql
@@ -1,4 +1,4 @@
-{% test sum_aggregate_matches_source(model, column_name, source_model, source_field, source_metric, comparison_field, percent_mismatch_threshold = 0) %}
+{% test count_aggregate_matches_source(model, column_name, source_model, source_field, source_metric, comparison_field, percent_mismatch_threshold = 0) %}
 
 {% set max_index = comparison_field|length %}
 

--- a/tests/generic/test_count_distinct_matches_source.sql
+++ b/tests/generic/test_count_distinct_matches_source.sql
@@ -1,39 +1,56 @@
-{% test count_aggregate_matches_source(model, column_name, source_model, source_field, source_metric, comparison_field, percent_mismatch_threshold = 0) %}
+{% test sum_aggregate_matches_source(model, column_name, source_model, source_field, source_metric, comparison_field, percent_mismatch_threshold = 0) %}
+
+{% set max_index = comparison_field|length %}
 
 with src as (
     select
-        {{ source_field }} as date,
-        {{ source_metric }} as measure_src
+        {% for dimension in source_field %}
+        {{ dimension }} as dim_{{ loop.index }},
+        {% endfor %}
+        sum({{ source_metric }}) as measure_src
 
     from {{ source_model }}
+    group by
+        {% for dimension in source_field %}
+        {{ dimension }}{% if not loop.last %},{% endif %}
+        {% endfor %}
 ),
 
 new_model as (
     select
-        {{ comparison_field }} as date,
+        {% for dimension in comparison_field %}
+        {{ dimension }} as dim_{{ loop.index }},
+        {% endfor %}
         count(distinct {{ column_name }}) as measure_comparison
 
     from {{ model }}
 
-    group by date
+    group by
+        {% for dimension in comparison_field %}
+        {{ dimension }}{% if not loop.last %},{% endif %}
+        {% endfor %}
 ),
 
 comparison as (
     select
-        coalesce(src.date, new_model.date) as date,
+        {% for num in range(1, max_index + 1) %}
+            coalesce(src.dim_{{ i }}, new_model.dim_{{ i }}) as dim_{{ num }},
+        {% endfor %}
         src.measure_src,
         new_model.measure_comparison,
         case
-        	when src.measure_src = 0 then src.measure_src = new_model.measure_comparison
+        	when coalesce(src.measure_src, 0) = 0 then src.measure_src = new_model.measure_comparison
             -- for scenarios where source_value = 0 and comparison_value = 0, this will return true
         	-- for scenarios where source_value = 0 and comparison_value = ±1+, this will return false no matter the threshold
-            when src.measure_src != 0 then abs(round((div0(new_model.measure_comparison, src.measure_src) - 1), 3)) <= ( {{ percent_mismatch_threshold }} / 100.0 )
+            when src.measure_src != 0 then abs(round(((new_model.measure_comparison / nullif(src.measure_src, 0)) - 1), 3)) <= ( {{ percent_mismatch_threshold }} / 100.0 )
             -- for scenarios where source_value ±1+ and comparison_value = ±1+ so the div0 function can work
             -- this will return false if the percent difference between both values are above error threshold set in yml file
         else false
         end as is_match
     from src
-    full outer join new_model on new_model.date = src.date
+    full outer join new_model 
+        on {% for i in range(1, max_index + 1) %} src.dim_{{ i }} = new_model.dim_{{ i }} {% if not loop.last %} and {% endif %}{% endfor %}
+
 )
 
 select * from comparison

--- a/tests/generic/test_sum_matches_source.sql
+++ b/tests/generic/test_sum_matches_source.sql
@@ -1,39 +1,56 @@
 {% test sum_aggregate_matches_source(model, column_name, source_model, source_field, source_metric, comparison_field, percent_mismatch_threshold = 0) %}
 
+{% set max_index = comparison_field|length %}
+
 with src as (
     select
-        {{ source_field }} as date,
-        {{ source_metric }} as measure_src
+        {% for dimension in source_field %}
+        {{ dimension }} as dim_{{ loop.index }},
+        {% endfor %}
+        sum({{ source_metric }}) as measure_src
 
     from {{ source_model }}
+    group by
+        {% for dimension in source_field %}
+        {{ dimension }}{% if not loop.last %},{% endif %}
+        {% endfor %}
 ),
 
 new_model as (
     select
-        {{ comparison_field }} as date,
+        {% for dimension in comparison_field %}
+        {{ dimension }} as dim_{{ loop.index }},
+        {% endfor %}
         sum({{ column_name }}) as measure_comparison
 
     from {{ model }}
 
-    group by date
+    group by
+        {% for dimension in comparison_field %}
+        {{ dimension }}{% if not loop.last %},{% endif %}
+        {% endfor %}
 ),
 
 comparison as (
     select
-        coalesce(src.date, new_model.date) as date,
+        {% for num in range(1, max_index + 1) %}
+            coalesce(src.dim_{{ i }}, new_model.dim_{{ i }}) as dim_{{ num }},
+        {% endfor %}
         src.measure_src,
         new_model.measure_comparison,
         case
-        	when src.measure_src = 0 then src.measure_src = new_model.measure_comparison
+        	when coalesce(src.measure_src, 0) = 0 then src.measure_src = new_model.measure_comparison
             -- for scenarios where source_value = 0 and comparison_value = 0, this will return true
         	-- for scenarios where source_value = 0 and comparison_value = ±1+, this will return false no matter the threshold
-            when src.measure_src != 0 then abs(round((div0(new_model.measure_comparison, src.measure_src) - 1), 3)) <= ( {{ percent_mismatch_threshold }} / 100.0 )
+            when src.measure_src != 0 then abs(round(((new_model.measure_comparison / nullif(src.measure_src, 0)) - 1), 3)) <= ( {{ percent_mismatch_threshold }} / 100.0 )
             -- for scenarios where source_value ±1+ and comparison_value = ±1+ so the div0 function can work
             -- this will return false if the percent difference between both values are above error threshold set in yml file
         else false
         end as is_match
     from src
-    full outer join new_model on new_model.date = src.date
+    full outer join new_model 
+        on {% for i in range(1, max_index + 1) %} src.dim_{{ i }} = new_model.dim_{{ i }} {% if not loop.last %} and {% endif %}{% endfor %}
+
 )
 
 select * from comparison


### PR DESCRIPTION
# Summary
- Added ability to implement source comparison tests that have additional dimensions other than `date`

### Before
- Source comparison tests were limited to only aggregating by 1 dimension -> this was mostly by date, as it offered more fields for comparison e.g. `date` | `revenue`

# Detailed Summary
The generic test now (new updates):
- grabs a list of dimensions outlined in the yaml configuration and renames this to `dim_1`, `dim_2` ...`dim_n`
- applies a full outer join on each dimension from `source` / `target comparison` i.e. `source.dim_1` = `target_comparison.dim_n`

# Note
- This requires the user to order the dimensions correctly i.e. `date`, `platform`, `country` must align in this order in the configuration

